### PR TITLE
支持with方式自定义header

### DIFF
--- a/src/Pay/Client.php
+++ b/src/Pay/Client.php
@@ -129,6 +129,11 @@ class Client implements HttpClientInterface
                 $options['headers']['Content-Type'] = 'text/xml';/** @phpstan-ignore-line */
             }
         }
+        
+        // 合并通过 withHeader 和 withHeaders 设置的信息
+        if (!empty($this->prependHeaders)) {
+            $options['headers'] = array_merge($this->prependHeaders, $options['headers'] ?? []);
+        }
 
         return new Response($this->client->request($method, $url, $options), throw: $this->throw);
     }


### PR DESCRIPTION
目前可以通过 withOptions 的方式自定义 header，但是代码中看到有 withHeader 和 withHeaders 这2个单独对header设置的方法，使用之。

```
$apiClient = EasyWeChat::pay()->getClient();
$apiClient->withHeader('Wechatpay-Serial', 'adfasdsadfa')->postJson('v3/transfer/batches', []);
```